### PR TITLE
Fix for allowing total thinning

### DIFF
--- a/trunk/src/PartialThinning.cs
+++ b/trunk/src/PartialThinning.cs
@@ -74,13 +74,6 @@ namespace Landis.Library.BiomassHarvest
             TextReader.SkipWhitespace(reader);
             index = reader.Index;
 
-            //  Read left parenthesis
-            int nextChar = reader.Peek();
-            if (nextChar == -1)
-                throw new InputValueException();  // Missing value
-            if (nextChar != '(')
-                throw MakeInputValueException(TextReader.ReadWord(reader),
-                                              "Value does not start with \"(\"");
             StringBuilder valueAsStr = new StringBuilder();
             valueAsStr.Append((char) (reader.Read()));
 
@@ -101,7 +94,7 @@ namespace Landis.Library.BiomassHarvest
                 throw MakeInputValueException(valueAsStr.ToString(),
                                               exc.Message);
             }
-            if (percentage < 0.0 || percentage > 0.99)
+            if (percentage.Value < 0.0 || percentage.Value > 0.99)
                 throw MakeInputValueException(valueAsStr.ToString(),
                                               string.Format("{0} is not between 0% and 99%.  100% is indicated by leaving out the %.", word));
 
@@ -183,6 +176,15 @@ namespace Landis.Library.BiomassHarvest
                 int ignore;
                 InputValue<Percentage> percentage = ReadPercentage(reader, out ignore);
                 percentages[ageRange.Start] = percentage;
+            }
+            else if(reader.Peek() == -1)
+            {
+                throw new InputValueException();  // Missing value
+            }
+            else if(reader.Peek() != '(')
+            {
+                throw MakeInputValueException(TextReader.ReadWord(reader),
+                                              "Value does not start with \"(\"");
             }
 
             return new InputValue<AgeRange>(ageRange, word);


### PR DESCRIPTION
Slightly altered percentage check to explicitly compare the percentage's
value to ensure it is between 0-99%. Also rearranged unreachable code to
throw an exception if a percentage is not specified.