### PR TITLE
Cutting bug fix

### DIFF
--- a/src/CohortCutterFactory.cs
+++ b/src/CohortCutterFactory.cs
@@ -26,9 +26,12 @@ namespace Landis.Library.BiomassHarvest
             if (PartialThinning.CohortSelectors.Count == 0)
                 cohortCutter = new WholeCohortCutter(cohortSelector, extensionType);
             else
+            {
                 cohortCutter = new PartialCohortCutter(cohortSelector,
                                                        PartialThinning.CohortSelectors,
                                                        extensionType);
+                PartialThinning.ClearCohortSelectors();
+            }
             return cohortCutter;
         }
 
@@ -48,9 +51,12 @@ namespace Landis.Library.BiomassHarvest
             if (PartialThinning.AdditionalCohortSelectors.Count == 0)
                 cohortCutter = new WholeCohortCutter(cohortSelector, extensionType);
             else
+            {
                 cohortCutter = new PartialCohortCutter(cohortSelector,
                                                        PartialThinning.AdditionalCohortSelectors,
                                                        extensionType);
+                PartialThinning.ClearCohortSelectors();
+            }
             return cohortCutter;
         }
     }

--- a/src/PartialThinning.cs
+++ b/src/PartialThinning.cs
@@ -242,5 +242,24 @@ namespace Landis.Library.BiomassHarvest
                 return true;
             }
         }
+
+        /// <summary>
+        /// Resets the cohort selectors for another prescription
+        /// </summary>
+        public static void ClearCohortSelectors()
+        {
+            if (CohortSelectors != null)
+            {
+                CohortSelectors.Clear();
+            }
+            if (AdditionalCohortSelectors != null)
+            {
+                AdditionalCohortSelectors.Clear();
+            }
+            if (percentages != null)
+            {
+                percentages.Clear();
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolved an issue where prescriptions would cut additional species that were not specified in the prescription.

The problem was there was only one set of cohort selectors for partial thinning being used for every prescription. These values were never cleared for the next prescription, so they would be reused even if the next prescription specified no partial thinning. This has been fixed so that these would be reset upon each prescription's initialization.