### PR TITLE
Allow 100% percentages to be used, update assembly file

### DIFF
--- a/src/PartialThinning.cs
+++ b/src/PartialThinning.cs
@@ -106,9 +106,9 @@ namespace Landis.Library.BiomassHarvest
                 throw MakeInputValueException(valueAsStr.ToString(),
                                               exc.Message);
             }
-            if (percentage.Value < 0.0 || percentage.Value > 0.99)
+            if (percentage.Value < 0.0 || percentage.Value > 1)
                 throw MakeInputValueException(valueAsStr.ToString(),
-                                              string.Format("{0} is not between 0% and 99%.  100% is indicated by omitting the parentheses and percentage.", word));
+                                              string.Format("{0} is not between 0% and 100%.", word));
 
             //  Read whitespace and ')'
             valueAsStr.Append(ReadWhitespace(reader));
@@ -187,7 +187,11 @@ namespace Landis.Library.BiomassHarvest
             if (reader.Peek() == '(') {
                 int ignore;
                 InputValue<Percentage> percentage = ReadPercentage(reader, out ignore);
-                percentages[ageRange.Start] = percentage;
+
+                if (percentage.String != "(100%)")
+                {
+                    percentages[ageRange.Start] = percentage;
+                }
             }
 
             return new InputValue<AgeRange>(ageRange, word);

--- a/src/library-biomass-harvest.csproj
+++ b/src/library-biomass-harvest.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Landis.Library.BiomassHarvest-v3</AssemblyTitle>
     <AssemblyCompany>LANDIS-II Foundation</AssemblyCompany>
     <AssemblyProduct>Landis.Library.BiomassHarvest-v3</AssemblyProduct>    
-    <AssemblyVersion>3.1</AssemblyVersion>
+    <AssemblyVersion>3.2</AssemblyVersion>
     <AssemblyDescription>Harvest Library for LANDIS-II</AssemblyDescription>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -18,12 +18,12 @@
     <Authors>LANDIS-II Foundation</Authors>    
     <Product>Library Biomass Harvest</Product>    
     <Copyright>LANDIS-II Foundation</Copyright>
-    <Version>3.1</Version>
+    <Version>3.2</Version>
     <PackageTags>LANDIS-II;Landis;Library;Biomass harvest</PackageTags>
     <Description>Library-Biomass-Harvest is a support library for Extension Biomass Harvest.
 Extension Biomass Harvest is found at: (https://github.com/LANDIS-II-Foundation/Extension-Biomass-Harvest)</Description>
     <PackageReleaseNotes>.NET Standard 2.0 update.</PackageReleaseNotes>
-    <FileVersion>3.1</FileVersion>
+    <FileVersion>3.2</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Users can now choose to omit the percentage or put 100% to indicate a complete harvest